### PR TITLE
Add queries tag to fix package visibilty API >= 30

### DIFF
--- a/auth/src/main/AndroidManifest.xml
+++ b/auth/src/main/AndroidManifest.xml
@@ -21,4 +21,8 @@
             </intent-filter>
         </receiver>
     </application>
+
+    <queries>
+        <package android:name="com.farsitel.bazaar" />
+    </queries>
 </manifest>

--- a/auth/src/main/AndroidManifest.xml
+++ b/auth/src/main/AndroidManifest.xml
@@ -1,6 +1,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.farsitel.bazaar.auth">
 
+    <queries>
+        <package android:name="com.farsitel.bazaar" />
+    </queries>
+
     <application>
         <activity
             android:name=".view.BazaarInstallerActivity"
@@ -21,8 +25,4 @@
             </intent-filter>
         </receiver>
     </application>
-
-    <queries>
-        <package android:name="com.farsitel.bazaar" />
-    </queries>
 </manifest>


### PR DESCRIPTION
Fixed package visibilty API>=30.
When an application use compileSdkVersion of 30, CafeBazaarAuth can not check for Bazaar application package info because of package visibility limit in API>=30.
So we should add Bazaar package to `<queries>` tag in manifest.